### PR TITLE
adds more missing regions

### DIFF
--- a/backend-monitorApp/lambda/index.js
+++ b/backend-monitorApp/lambda/index.js
@@ -13,6 +13,7 @@ const regions = [
 	'ap-northeast-1',   // Tokyo
 	'ap-northeast-2',   // Seoul
 	'ap-northeast-3',   // Osaka-Local
+	'ap-east-1',        // Hong Kong
 	'ap-south-1',       // Mumbai
 	'ap-southeast-1',   // Singapore
 	'ap-southeast-2',   // Sydney
@@ -22,6 +23,8 @@ const regions = [
 	'eu-central-1',     // Frankfurt
 	'eu-west-1',        // Ireland
 	'eu-west-2',        // London
+	'eu-west-3',        // Paris
+	'eu-north-1',       // Stockholm
 	'us-east-1',        // N Virginia
 	'us-east-2',        // Ohio
 	'us-west-1',        // N California

--- a/backend-monitorApp/lambda/index.js
+++ b/backend-monitorApp/lambda/index.js
@@ -12,10 +12,13 @@ var marshalItem = require('dynamodb-marshaler');
 const regions = [
 	'ap-northeast-1',   // Tokyo
 	'ap-northeast-2',   // Seoul
+	'ap-northeast-3',   // Osaka-Local
 	'ap-south-1',       // Mumbai
 	'ap-southeast-1',   // Singapore
 	'ap-southeast-2',   // Sydney
 	'ca-central-1',     // Canada Central
+	'cn-north-1',       // China (Beijing)
+	'cn-northwest-1',   // China (Ningxia)
 	'eu-central-1',     // Frankfurt
 	'eu-west-1',        // Ireland
 	'eu-west-2',        // London
@@ -23,7 +26,10 @@ const regions = [
 	'us-east-2',        // Ohio
 	'us-west-1',        // N California
 	'us-west-2',        // Oregon
+	'us-gov-east-1',    // AWS GovCloud (US-East)
+	'us-gov-west-1',    // AWS GovCloud (US-West)
 	'sa-east-1',        // Brazil
+	'me-south-1',       // Bahrain
 ];
 
 const pingRegionAsync = function (region) {


### PR DESCRIPTION
This PR in combination with [this](https://github.com/mda590/cloudping.co/pull/29) should add the missing regions.

I was uncertain how to actually test this locally but the change seems simple.

Although, it looks like Osaka (`ap-northeast-3`) might not be supporting Lambda so that one might not be as simple.