### PR TITLE
New region: Canada West (Calgary)

### DIFF
--- a/backend-monitorApp/lambda/index.js
+++ b/backend-monitorApp/lambda/index.js
@@ -16,6 +16,7 @@ const regions = [
 	'ap-southeast-1',   // Singapore
 	'ap-southeast-2',   // Sydney
 	'ca-central-1',     // Canada Central
+	'ca-west-1',        // Canada West
 	'eu-central-1',     // Frankfurt
 	'eu-west-1',        // Ireland
 	'eu-west-2',        // London


### PR DESCRIPTION
Add support for the ca-west-1 region, launched on 2023-Dec-20.

https://aws.amazon.com/blogs/aws/the-aws-canada-west-calgary-region-is-now-available/