### PR TITLE
fix region refresh on percentile/timeframe update

### DIFF
--- a/cloudping-frontend-njs/components/LatencyMatrix.tsx
+++ b/cloudping-frontend-njs/components/LatencyMatrix.tsx
@@ -41,22 +41,10 @@ export default function LatencyMatrix({ initialData }: LatencyMatrixProps) {
     if (data?.data) {
       const newRegions = Object.keys(data.data).sort();
       setSelectedRegions(prevSelected => {
-        // Add any new regions to the selection
-        const updatedSelection = [...prevSelected];
-        let changed = false;
-        
-        newRegions.forEach(region => {
-          if (!prevSelected.includes(region)) {
-            updatedSelection.push(region);
-            changed = true;
-          }
-        });
-        
-        // Only update state if there were changes
-        return changed ? updatedSelection : prevSelected;
+        return prevSelected.filter((region) => newRegions.includes(region));
       });
     }
-  }, [data]); // Remove selectedRegions from dependency array
+  }, [data]);
 
   const getLatencyColor = (latency: number): string => {
     if (latency < 100) return 'bg-green-500';


### PR DESCRIPTION
fix: sync region selection when percentile or timeframe updates

## Summary

When the user changes percentile or timeframe, the app refetches latency data via [updateData](cloudping-frontend-njs/components/LatencyMatrix.tsx) and replaces data. The available region keys come from Object.keys(data.data).

Previously, the useEffect that runs on [data] tried to merge newly appearing regions into selectedRegions. It did not reliably align the selection with the current payload when the set of regions changed in other ways, which led to a poor “refresh” experience after filter/timeframe updates.

This change replaces that merge logic with a simple intersection: keep only the previously selected regions that still exist in the latest data.data.

## Behavior note
* **Removed**: automatically adding newly introduced region keys to the selection whenever the API returns more regions than before (the assumption is that addition of a new region should be a pretty rare use-case, reinforced by the fact that data is updated every 6h).
* **Gained**: selections never reference regions that are absent from the current response, so the matrix and region filter stay consistent after percentile/timeframe (or any data) updates.

## How to verify (manual)
1. Open the latency matrix with a dataset that lists regions.
2. Narrow the region selection in the filter panel.
3. Change percentile or timeframe and confirm selected regions only include regions present in the new response (no stale labels / empty rows from old keys).
4. Optionally: load a response with additional regions vs. the previous one and confirm new regions are not auto-selected unless the user selects them (if product expects auto-select for new regions, that would be a follow-up).